### PR TITLE
Null Map Check

### DIFF
--- a/Source/HarmonyPatches_MapGenerator.cs
+++ b/Source/HarmonyPatches_MapGenerator.cs
@@ -474,6 +474,11 @@ namespace ImpassableMapMaker
         [HarmonyPriority(Priority.First)]
         static void Postfix(ref Map __result, MapGeneratorDef mapGenerator)
         {
+            if (__result == null)
+            {
+                Log.Warning("Map is null, impassable map generation will be skipped.");
+                return;
+            }
             if (__result.TileInfo.hilliness == Hilliness.Impassable && Settings.OuterShape == ImpassableShape.Fill)
             {
                 int maxX = __result.Size.x - 1;


### PR DESCRIPTION
Added a null checker so that map generation doesn't fail when `__result` is null.

This should normally not happen, but [SOS2 Experimental](https://github.com/SonicTHI/SaveOurShip2Experimental) currently blocks ship maps from map generation so that it can generate its own later via its postfix. Said postfix is called after this mod's own, which causes the issue as `__result` will be null when `Patch_MapGenerator_Generate.Postfix()` is called first.